### PR TITLE
 Added Dark/Light Theme Toggle for GUI

### DIFF
--- a/img_upload_oop.py
+++ b/img_upload_oop.py
@@ -2,25 +2,84 @@ import glob
 from tkinter import *
 from tkinter import filedialog, messagebox
 from PIL import Image
-import os,shutil
+import os, shutil
+
+# Defining Light and Dark Theme Dictionaries
+LIGHT_THEME = {
+    "bg": "white",
+    "fg": "black",
+    "button_bg": "#f0f0f0",
+    "button_fg": "black"
+}
+
+DARK_THEME = {
+    "bg": "#4A4848",
+    "fg": "white",
+    "button_bg": "#444444",
+    "button_fg": "white"
+}
+
+# Global flag
+is_dark_mode = False
 
 class main():
-    def __init__(self,root):
-        self.root=root
+    def __init__(self, root):
+        self.root = root
         self.root.title("Option window")
-        self.root.geometry('160x50+190+30')
-        self.root.resizable(False,False)
-        self.root.config(bg="#4A4848")
+        self.root.geometry('400x220')  # Increased height for extra button
+        self.root.resizable(False, False)
         
+        # Apply default theme (light)
+        self.theme = LIGHT_THEME
+        self.apply_theme()
+
         # self.fldr_exists()
 
-        Button(self.root, text="Save Image", font=("goudy old style", 20, "bold"), bg="#eb5834", fg="white", cursor="hand2",bd=10,relief=RIDGE,command=self.save_img).pack()
-
+         # Save Image Button
+        self.save_btn = Button(
+            self.root, text="Save Image",
+            font=("goudy old style", 15, "bold"),
+            bg=self.theme["button_bg"],
+            fg=self.theme["button_fg"],
+            cursor="hand2", bd=5, relief=RIDGE,
+            command=self.save_img
+        )
+        self.save_btn.pack(pady=5)
         
+        # Toggle Theme Button
+        self.toggle_btn = Button(
+            self.root, text="Toggle Theme",
+            font=("goudy old style", 12, "bold"),
+            bg=self.theme["button_bg"],
+            fg=self.theme["button_fg"],
+            cursor="hand2", bd=3, relief=RIDGE,
+            command=self.toggle_theme
+        )
+        self.toggle_btn.pack(pady=5)
         
         # Button(self.root, text="Rename Image", font=("goudy old style", 20, "bold"), bg="#e4f2e5", fg="blue", cursor="hand2",bd=10,relief=RIDGE,command=self.rename).place(x=320, y=270, width=200, height=100)
         # Button(self.root, text="STUDENT", font=("goudy old style", 20, "bold"), bg="#0c8518", fg="white", cursor="hand2",bd=10,relief=RIDGE,command=self.std_win).place(x=570, y=270, width=200, height=100)
 
+    def apply_theme(self):
+        """🔥 Apply the current theme to root and widgets"""
+        self.root.config(bg=self.theme["bg"])
+
+    def update_widgets_theme(self):
+        """🔥 Update widget colors on toggle"""
+        self.save_btn.config(
+            bg=self.theme["button_bg"], fg=self.theme["button_fg"]
+        )
+        self.toggle_btn.config(
+            bg=self.theme["button_bg"], fg=self.theme["button_fg"]
+        )
+        self.root.config(bg=self.theme["bg"])
+
+    def toggle_theme(self):
+        """🔥 Toggle dark/light theme"""
+        global is_dark_mode
+        is_dark_mode = not is_dark_mode
+        self.theme = DARK_THEME if is_dark_mode else LIGHT_THEME
+        self.update_widgets_theme()
 
     # def open_img(self):
     #     file_path = filedialog.askopenfilenames()


### PR DESCRIPTION
## 🧩 Summary
This PR implements a Dark/Light mode toggle in the main GUI window (`img_upload_oop.py`) to enhance usability and accessibility in different lighting conditions.

## Features Implemented
- Added `LIGHT_THEME` and `DARK_THEME` dictionaries for styling
- Global flag `is_dark_mode` to track current mode
- `toggle_theme()` function to switch themes
- Added a "Toggle Theme" button below the existing "Save Image" button
- Updated window size for better layout and spacing

## Files Changed
- `img_upload_oop.py`

## Issue Reference
Closes #1

## 🙋‍♂️ Contributor Note
Let me know if any improvements are needed. Excited to take up more enhancements like modern styling and animations in a future PR!